### PR TITLE
:rocket:Add Support for Customer Eligibility (Drone-Eligible Nodes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ Optional keyword arguments for `solve_tspd`:
 n_groups::Int = 1, 
 method::String = "TSP-ep-all", 
 flying_range::Float64 = MAX_DRONE_RANGE, 
-time_limit::Float64 = MAX_TIME_LIMIT
+time_limit::Float64 = MAX_TIME_LIMIT,
+initial_tour::Union{Vector{Int}, Nothing} = nothing,
+drone_eligible::Union{Nothing, Set{Int}} = nothing
 ```
 * `n_groups`: The number of subgroups for divide and conquer. For example, if `n=100` and `n_groups=4`, then each group will have `25` nodes. Then, `method` is applied for each group. 
 * `method`: can be one of the following (See [Agatz et al. 2018](https://doi.org/10.1287/trsc.2017.0791)):
@@ -147,7 +149,9 @@ time_limit::Float64 = MAX_TIME_LIMIT
     - `"TSP-ep-2opt"`: All possible 2-opt exchange moves.
     - `"TSP-ep-all"`: All possible 1p, 2p, and 2opt moves.
 * `flying_range`: The limited flying range of the drone. The default value is `Inf`. The flying range is compared with the values in the drone cost matrix; that is, `drone_cost_mtx` or the Euclidean distance multiplied by `drone_cost_factor`. 
-* `time_limit`: The total time limit to solve the problem in seconds. For each group, the time limit is split equally. For example, if `time_limit=3600.0` and `n_groups=5`, then each group has time limit of 3600/5 = 720 seconds. 
+* `time_limit`: The total time limit to solve the problem in seconds. For each group, the time limit is split equally. For example, if `time_limit=3600.0` and `n_groups=5`, then each group has time limit of 3600/5 = 720 seconds.
+* `initial_tour`: Optional initial TSP tour. If `nothing`, a TSP tour is computed using Concorde. The tour should start at node 1 and end at node `n+1` (dummy depot). If the final depot is missing, it will be added automatically.
+* `drone_eligible`: Set of nodes that can be served by the drone. If `nothing`, all nodes are eligible. Nodes not in this set will only be served by the truck. 
 
 
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -43,12 +43,13 @@ function solve_tspd(
     method::String = "TSP-ep-all", 
     flying_range::Float64 = MAX_DRONE_RANGE, 
     time_limit::Float64 = MAX_TIME_LIMIT,
-    initial_tour::Union{Vector{Int}, Nothing}=nothing
+    initial_tour::Union{Vector{Int}, Nothing}=nothing,
+    drone_eligible::Union{Nothing,Set{Int}}=nothing
 )
     local_search_methods = local_search_functions(method)
     Ct, Cd = cost_matrices_with_dummy(x, y, truck_cost_factor, drone_cost_factor)
 
-    total_tspd_len, truck_route, drone_route = divide_partition_search(Ct, Cd; local_search_methods=local_search_methods, n_groups=n_groups, flying_range=flying_range, time_limit=time_limit, initial_tour=initial_tour)
+    total_tspd_len, truck_route, drone_route = divide_partition_search(Ct, Cd; local_search_methods=local_search_methods, n_groups=n_groups, flying_range=flying_range, time_limit=time_limit, initial_tour=initial_tour, drone_eligible=drone_eligible)
 
     result = TSPDroneResult(total_tspd_len, truck_route, drone_route, Ct, Cd, flying_range)
     return result
@@ -62,12 +63,13 @@ function solve_tspd(
     method::String = "TSP-ep-all", 
     flying_range::Float64 = MAX_DRONE_RANGE, 
     time_limit::Float64 = MAX_TIME_LIMIT,
-    initial_tour::Union{Vector{Int}, Nothing}=nothing
+    initial_tour::Union{Vector{Int}, Nothing}=nothing,
+    drone_eligible::Union{Nothing,Set{Int}}=nothing
 )
     Ct, Cd = cost_matrices_with_dummy(truck_cost_mtx, drone_cost_mtx)
     local_search_methods = local_search_functions(method)
 
-    total_tspd_len, truck_route, drone_route = divide_partition_search(Ct, Cd; local_search_methods=local_search_methods, n_groups=n_groups, flying_range=flying_range, time_limit=time_limit, initial_tour=initial_tour)
+    total_tspd_len, truck_route, drone_route = divide_partition_search(Ct, Cd; local_search_methods=local_search_methods, n_groups=n_groups, flying_range=flying_range, time_limit=time_limit, initial_tour=initial_tour, drone_eligible=drone_eligible)
 
     result = TSPDroneResult(total_tspd_len, truck_route, drone_route, Ct, Cd, flying_range)
     return result


### PR DESCRIPTION
## Summary

This PR adds support for **customer eligibility** constraints, allowing users to specify which nodes can be served by the drone. Nodes not in the `drone_eligible` set will only be served by the truck.

## Changes

### Core Functions Modified

1. **`exact_partitioning`** (`src/tsp_ep_all.jl`)
   - Added `drone_eligible::Union{Nothing,Set{Int}}` parameter
   - Skips non-eligible nodes when evaluating drone assignments
   - Works with both infinite and finite `flying_range`
   - Maintains all existing optimizations (quadratic EP boost, distance ordering)

2. **`tsp_ep_all`** (`src/tsp_ep_all.jl`)
   - Added `drone_eligible` parameter to both overloaded functions
   - Passes constraint through to `exact_partitioning` in all local search iterations

3. **`divide_partition_search`** (`src/DPS.jl`)
   - Added `drone_eligible` parameter
   - Maps original node IDs to group-local indices when dividing into groups
   - Ensures eligibility constraints are preserved across divide-and-conquer

4. **`solve_tspd`** (`src/main.jl`)
   - Added `drone_eligible` parameter to both overloaded functions
   - Passes constraint through to DPS algorithm

### Implementation Details

- **Type Safety**: Uses `Set{Int}` (concrete type) instead of `AbstractSet{Int}` for better performance
- **Backward Compatible**: `drone_eligible=nothing` (default) means all nodes are eligible (original behavior)
- **Efficient Filtering**: Non-eligible nodes are skipped early in evaluation loops using `continue`
- **Node Mapping**: DPS correctly maps eligibility constraints when dividing into groups

## Use Cases

- **Physical Constraints**: Some customers may be in locations where drone delivery is not allowed (e.g., restricted airspace, no landing zones)
- **Regulatory Constraints**: Certain areas may prohibit drone operations
- **Operational Constraints**: Some customers may prefer truck-only delivery
- **Testing & Analysis**: Restrict drone service to specific subsets for analysis

## Testing

All changes maintain backward compatibility. When `drone_eligible=nothing`, the behavior is identical to the original implementation.

## Example Scenarios

**Scenario 1: All nodes eligible (default)**
```julia
result = solve_tspd(x, y, 1.0, 0.5)  # drone_eligible=nothing
# Same as original behavior
```

**Scenario 2: Restricted eligibility**
```julia
result = solve_tspd(x, y, 1.0, 0.5; drone_eligible=Set([2, 3, 5]))
# Only nodes 2, 3, 5 can be served by drone
```

**Scenario 3: Truck-only (no eligible nodes)**
```julia
result = solve_tspd(x, y, 1.0, 0.5; drone_eligible=Set{Int}())
# All nodes served by truck only
```

